### PR TITLE
Support passing load paths via CLI

### DIFF
--- a/lib/cadenza/cli.rb
+++ b/lib/cadenza/cli.rb
@@ -7,8 +7,19 @@ module Cadenza
 
     def self.run!(path, options={})
 
-      root = options[:root] || File.expand_path(Dir.pwd)
-      Cadenza::BaseContext.add_loader Cadenza::FilesystemLoader.new(root)
+      load_paths =
+        if options[:root]
+          [options[:root]]
+        elsif options.key?(:load_paths) && [:load_paths].any?
+          options[:load_paths]
+        else
+          [Dir.pwd]
+        end
+
+      load_paths.each do |path|
+        Cadenza::BaseContext.add_load_path path
+      end
+
       Cadenza::BaseContext.whiny_template_loading = true
 
       Cadenza.render_template path, options[:context]

--- a/lib/cadenza/cli/options.rb
+++ b/lib/cadenza/cli/options.rb
@@ -21,6 +21,11 @@ module Cadenza::Cli
         @options[:context] = MultiJson.load(context)
       end
 
+      def add_load_path(path)
+        @options[:load_paths] ||= []
+        @options[:load_paths] << path
+      end
+
       def set_opts
         on("--context json") do |value|
           context_option value
@@ -30,6 +35,9 @@ module Cadenza::Cli
         end
         on("--root path") do |value|
           @options[:root] = value
+        end
+        on("-I", "--load-path PATH", "Add a path for the filesystem loader") do |path|
+          add_load_path(path)
         end
 
       end

--- a/lib/cadenza/context.rb
+++ b/lib/cadenza/context.rb
@@ -195,6 +195,17 @@ module Cadenza
          block.call(self, nodes, parameters)
       end
 
+      # constructs a {FilesystemLoader} with the string given as its path and
+      # adds the loader to the end of the loader list.
+      #
+      # @param [String] path to use for loader
+      # @return [Loader] the loader that was created
+      def add_load_path(path)
+        loader = FilesystemLoader.new(path)
+        add_loader(loader)
+        loader
+      end
+
       # adds the given loader to the end of the loader list.  If the argument 
       # passed is a string then a {FilesystemLoader} will be constructed with
       # the string given as a path for it.
@@ -202,11 +213,7 @@ module Cadenza
       # @param [Loader,String] loader the loader to add
       # @return nil
       def add_loader(loader)
-         if loader.is_a?(String)
-            @loaders.push FilesystemLoader.new(loader)
-         else
-            @loaders.push loader
-         end
+          @loaders.push loader
          nil
       end
 

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -277,9 +277,9 @@ describe Cadenza::Context do
          context.loaders.should == [filesystem_loader]
       end
 
-      it "should push a string object as a filesystem loader" do
+      it "should allow adding a load path" do
          path = fixture_filename("foo")
-         context.add_loader(path)
+         context.add_load_path(path)
 
          context.loaders.should have(1).item
          context.loaders[0].should be_a Cadenza::FilesystemLoader


### PR DESCRIPTION
Turns out the `--root` option is a little limiting for me. I now need to specify multiple paths via the CLI interface. This implements proper load path support (I copied from the Sass executable). N.B. I also refactored `add_loader`.
