### PR TITLE
implement Cadenza::ContextObject

### DIFF
--- a/lib/cadenza/context.rb
+++ b/lib/cadenza/context.rb
@@ -316,23 +316,8 @@ module Cadenza
             return scope[identifier] || scope[sym_identifier]
          end
 
-         #TODO: security vulnerability below, we use #send on an object which can
-         # allow us to call private or protected methods on an object.
-         # 
-         # We could use #public_send but it is only available in Ruby 1.9.x so 
-         # we would have to drop 1.8.7 support.
-         #
-         # Alternatively we could forbid binding regular objects to contexts
-         # entirely and require that any bound object is a subclass of Cadenza::Drop
-         # Knowing this we could take public methods defined on the object
-         # and subtract public methods defined on the drop to get a list of 
-         # safely callable methods. And it will work in 1.8.7
-         #
-         # This won't happen until Cadenza 0.8.0 however as it will possibly break
-         # backwards compatibility.
-
          # if the identifier is a callable method then call that
-         return scope.send(sym_identifier) if scope.respond_to?(sym_identifier)
+         return scope.send(:invoke_context_method, identifier) if scope.is_a?(Cadenza::ContextObject)
 
          # if a functional variable is defined matching the identifier name then return that
          return @functional_variables[sym_identifier] if @functional_variables.has_key?(sym_identifier)

--- a/lib/cadenza/context_object.rb
+++ b/lib/cadenza/context_object.rb
@@ -3,8 +3,36 @@ module Cadenza
    class ContextObject < Object # intentionally declared, since we cannot 
                                 # subclass BasicObject in 1.8.7
 
-      # this class is intentionally left blank as a placeholder, see 
-      # context_object_spec.rb under spec/ for details.
+   private
+      def before_method(method)
+         # no implementation, used by subclasses
+      end
+
+      def after_method(method)
+         # no implementation, used by subclasses
+      end
+
+      def missing_context_method(method)
+         # no implementation, used by subclasses
+      end
+
+      def invoke_context_method(method)
+         send(:before_method, method)
+         
+         if context_methods.include?(method.to_s)
+            result = send(method)
+         else
+            result = send(:missing_context_method, method)
+         end
+
+         send(:after_method, method)
+
+         result
+      end
+
+      def context_methods
+         self.class.public_instance_methods.map(&:to_s)
+      end
       
    end
 end

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -90,24 +90,7 @@ describe Cadenza::Context do
    end
 
    context "#lookup" do
-      class ScopedClass
-         def public_method
-            123
-         end
-
-      protected
-         def protected_method
-            456
-         end
-
-      private
-         def private_method
-            789
-         end
-
-      end
-
-      let(:scope) { {:foo => {:bar => "baz"}, :abc => OpenStruct.new(:def => "ghi"), :alphabet => %w(a b c), :obj => ScopedClass.new} }
+      let(:scope) { {:foo => {:bar => "baz"}, :abc => OpenStruct.new(:def => "ghi"), :alphabet => %w(a b c), :obj => TestContextObject.new} }
       let(:assign) { lambda {|context, name, value| context.assign(name, value) } }
       let(:context) { Cadenza::Context.new(scope) }
 
@@ -143,10 +126,6 @@ describe Cadenza::Context do
          context.lookup("foo").should == {:bar => "baz"}
       end
 
-      it "should look up identifiers on an object if the object responds to that identifier" do
-         context.lookup("abc.def").should == "ghi"
-      end
-
       it "should look up array indexes" do
          context.lookup("alphabet.1").should == "b"
       end
@@ -155,14 +134,12 @@ describe Cadenza::Context do
          context.lookup("assign").should == assign
       end
 
-      it "should call methods on objects" do
+      it "calls methods on ContextObjects" do
          context.lookup("obj.public_method").should == 123
       end
 
-      it "should not call protected or private methods on objects" do
-         pending "does not currently work, will be supported in Cadenza 0.8.0"
-         context.lookup("obj.protected_method").should == nil
-         context.lookup("obj.private_method").should == nil
+      it "doesn't look up values on objects which are not ContextObjects" do
+         context.lookup("abc.def").should == nil
       end
    end
 

--- a/spec/support/test_context_object.rb
+++ b/spec/support/test_context_object.rb
@@ -1,0 +1,25 @@
+
+class TestContextObject < Cadenza::ContextObject
+   def public_method
+      123
+   end
+
+protected
+   def protected_method
+      123
+   end
+
+private
+   def before_method(method)
+   end
+
+   def after_method(method)
+   end
+
+   def missing_context_method(method)
+   end
+
+   def private_method
+      123
+   end
+end


### PR DESCRIPTION
- in order to be invokeable, all non-array, non-hash objects bound to the context must be subclasses
- before/after callbacks are available by implementing before_method(method) and after_method(method)
- a safe method_missing for context's is available by implementing missing_context_method(method)
