### PR TITLE
Make sure local variable doesn't hide parameter

### DIFF
--- a/lib/cadenza/cli.rb
+++ b/lib/cadenza/cli.rb
@@ -16,8 +16,8 @@ module Cadenza
           [Dir.pwd]
         end
 
-      load_paths.each do |path|
-        Cadenza::BaseContext.add_load_path path
+      load_paths.each do |load_path|
+        Cadenza::BaseContext.add_load_path load_path
       end
 
       Cadenza::BaseContext.whiny_template_loading = true


### PR DESCRIPTION
Accidentally hiding parameter with local variable. This was causing the CLI to use the last load path as the template to render, rather than the template name.
