### PR TITLE
Start adding error codes to executable

### DIFF
--- a/bin/cadenza
+++ b/bin/cadenza
@@ -7,4 +7,12 @@ require 'cadenza/cli'
 options = Cadenza::Cli::Options.parse!
 path = ARGV[0]
 
-STDOUT.puts Cadenza::Cli.run!(path, options)
+begin
+    STDOUT.puts Cadenza::Cli.run!(path, options)
+rescue Cadenza::TemplateNotFoundError => e
+    STDERR.puts "Couldn't find template - #{e.message}"
+    exit 66
+rescue Cadenza::Error => e
+    STDERR.puts "#{e.backtrace}"
+    exit 1
+end


### PR DESCRIPTION
In the app I'm building, I need to be able to determine exactly what went wrong if Cadenza fails. I've implemented one of BSD's [recommended exit codes][sysexits] for `Cadenza::TemplateNotFoundError`. Hopefully before long we'll have all of our error cases covered.
