### PR TITLE
Add docs badge to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 [![Gem Version](https://badge.fury.io/rb/cadenza.png)](http://badge.fury.io/rb/cadenza)
 [![Build Status](https://secure.travis-ci.org/whoward/cadenza.png?branch=master)](http://travis-ci.org/whoward/cadenza)
 [![Code Climate](https://codeclimate.com/github/whoward/cadenza.png)](https://codeclimate.com/github/whoward/cadenza)
+[![Inline docs](http://inch-pages.github.io/github/whoward/cadenza.png)](http://inch-pages.github.io/github/whoward/cadenza)
 
 # Description
 


### PR DESCRIPTION
I just added the badge you requested to your README: ![Inline docs](http://inch-pages.github.io/github/whoward/cadenza.png)

Your status page for this project is http://inch-pages.github.io/github/whoward/cadenza

Thanks for giving this a shot!
